### PR TITLE
removing jsx as dep

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 %]}.
 {profiles, [
   {test, [
-    {deps, [jsx]},
+    {deps, []},
     {escript_name, toml_test},
     {escript_incl_apps, [jsx]},
     {yrl_opts, [{verbose, true}]}


### PR DESCRIPTION
Don't see this functionality being retained in the current version.  Like what you're doing with maps over dicts.